### PR TITLE
fix: add the destroyAll function for ReferencesMany relation

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -3348,6 +3348,27 @@ ReferencesMany.prototype.destroyById = function(fkId, options, cb) {
   });
   return cb.promise;
 };
+/**
+ * This function is written by bitpodio team to prevent deletion of all modelTo related objects of referenceMany relation when we delete even one.
+ */
+
+ReferencesMany.prototype.destroyAll = function(id, options, cb) {
+  if (typeof options === "function" && cb === undefined) {
+    cb = options;
+    options = {};
+  }
+  cb = cb || utils.createPromiseCallback();
+  const modelTo = this.definition.modelTo;
+  const modelFrom = this.definition.modelFrom;
+  const relationName = this.definition.name;
+  const modelInstance = this.modelInstance;
+  const toDelete = modelInstance.__data[this.definition.keyFrom];
+  modelTo.destroyAll({id: {inq: toDelete}}, (err, data) => {
+    if (err) return cb(err);
+    cb(null, data)
+  });
+  return cb.promise;
+}
 
 ReferencesMany.prototype.at = function(index, options, cb) {
   if (typeof options === 'function' && cb === undefined) {

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -3189,6 +3189,8 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelToRe
   scopeMethods.build = scopeMethod(definition, 'build');
 
   scopeMethods.related = scopeMethod(definition, 'related');
+  
+  scopeMethods.destroyAll = scopeMethod(definition, 'destroyAll');
 
   var customMethods = extendScopeMethods(definition, scopeMethods, params.scopeMethods);
 


### PR DESCRIPTION
### Description
While deleting object linked via ReferencesMany relation, we will prevent deletion of all object of related model which was earlier the case.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
