### PR TITLE
fix:#3394 add referenceMany data in count apis to return actual length…

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1359,9 +1359,8 @@ DataAccessObject.findByIds = function(ids, query, options, cb) {
   // to know if the result need to be sorted by ids or not
   // this variable need to be initialized before the call to find, because filter is updated during the call with an order
   var toSortObjectsByIds = filter.order ? false : true;
-
   this.find(filter, options, function(err, results) {
-    cb(err, toSortObjectsByIds ? utils.sortObjectsByIds(pk, ids, results) : results);
+    cb(err, toSortObjectsByIds && typeof results !== 'number' ? utils.sortObjectsByIds(pk, ids, results) : results);
   });
   return cb.promise;
 };
@@ -1984,7 +1983,7 @@ DataAccessObject.find = function find(query, options, cb) {
             results = geo.filter(results, near);
           }
 
-          cb(err, results);
+          cb(err, options.returnCount ? results.length: results);
         });
       } else {
         cb(err, data || []);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -322,7 +322,8 @@ function defineScope(cls, targetClass, name, params, methods, options) {
 
   var fn_count = function(cb) {
     var f = this[name].count;
-    f.apply(this[name], arguments);
+    const formattedArgs =  this.__data ? [this.__data, ...arguments] : [{}, ...arguments];
+    f.apply(this[name], formattedArgs);
   };
 
   cls['__count__' + name] = fn_count;
@@ -443,23 +444,43 @@ function defineScope(cls, targetClass, name, params, methods, options) {
     filter = mergeQuery({where: scoped}, filter || {});
     return targetModel.findOne(filter, options, cb);
   }
-
-  function count(where, options, cb) {
-    if (typeof where === 'function') {
-      // count(cb)
-      cb = where;
-      where = {};
-    } else if (typeof options === 'function' && cb === undefined) {
-      // count(where, cb)
-      cb = options;
-      options = {};
+/**
+ *
+ * @param  {...any} args
+ *  it could receive variable number of agruments,
+ * So we'll check and assign according to length of args and data type.
+ * The key is to maintain this order: data, where, options, cb.
+ * cb can be undefined as it will is autocreated further if found missing.
+ *
+ */
+  function count(...args) {
+    let data = {}, where = {}, options = {}, cb;
+    if (args.length === 4) {
+      data = args[0];
+      where = args[1];
+      options = args[2];
+      cb = args[3];
+    } else if (args.length === 3) {
+      where = args[0];
+      options = args[1];
+      cb = args[2];
     }
-    options = options || {};
-
+    else if (args.length === 2) {
+      where = args[0];
+      cb = args[1];
+    }
+    else if (args.length === 1) {
+      if (typeof args[0] === 'function') {
+        cb = args[0];
+      } else {
+        where = args[0];
+      }
+    }
     var targetModel = definition.targetModel(this._receiver);
     var scoped = (this._scope && this._scope.where) || {};
     var filter = mergeQuery({where: scoped}, {where: where || {}});
-    return targetModel.count(filter.where, options, cb);
+    options.returnCount = true;
+    return definition.related(data, scoped, filter, options, cb);
   }
 
   return definition;


### PR DESCRIPTION
… insteadof whole target instances count

### Description
The count api in juggler doesn't return valid count for related models. It has a generalized count which returns length of all documents instead of just related documents.

So the count function is modified to use the find function and with a special flag "returnCount" we will return the length of records instead of records itself.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
